### PR TITLE
Fix null local mac problem

### DIFF
--- a/libremap-agent/luasrc/libremap/plugins/wireless.lua
+++ b/libremap-agent/luasrc/libremap/plugins/wireless.lua
@@ -45,7 +45,7 @@ local function read_wifilinks()
    local macs = {}
    for _, dev in ipairs(wifidevs) do
       for _, net in ipairs(dev:get_wifinets()) do
-         local local_mac = ntm:get_interface(net.iwdata.ifname):mac()
+         local local_mac = ntm:get_interface(net.iwdata.ifname).dev.macaddr
          local channel = net:channel()
          local assoclist = net.iwinfo.assoclist or {}
          for station_mac, link_data in pairs(assoclist) do


### PR DESCRIPTION
Probably something changed in OpenWRT Barrier Braker.
Local mac reported by libremap agent was 00:00:00:00:00:00, so WiFi links were not printed properly.
This patch fixes it.
