### PR TITLE
Replace luci.fs require with nixio.fs

### DIFF
--- a/libremap-agent/luasrc/libremap.lua
+++ b/libremap-agent/luasrc/libremap.lua
@@ -13,7 +13,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 local libremap = {}
 
-local fs = require 'luci.fs'
+local fs = require 'nixio.fs'
 local httpc = require 'luci.httpclient'
 local json = require 'luci.json'
 local sys = require 'luci.sys'

--- a/libremap-agent/luasrc/libremap/plugins/wireless.lua
+++ b/libremap-agent/luasrc/libremap/plugins/wireless.lua
@@ -45,7 +45,7 @@ local function read_wifilinks()
    local macs = {}
    for _, dev in ipairs(wifidevs) do
       for _, net in ipairs(dev:get_wifinets()) do
-         local local_mac = ntm:get_interface(net.iwdata.ifname).dev.macaddr
+         local local_mac = string.upper(ntm:get_interface(net.iwdata.ifname).dev.macaddr)
          local channel = net:channel()
          local assoclist = net.iwinfo.assoclist or {}
          for station_mac, link_data in pairs(assoclist) do


### PR DESCRIPTION
Hi,

On the 15th January 2015 the file luci.fs was dropped from [luci-base](https://github.com/openwrt/luci/commit/e91b603acc0920f998ae57704a9d97b83ee284e4)[1], causing libremap-agent to crash because of the missing required file:

```
root@qMp-3a56:~# /usr/sbin/libremap-agent 
/usr/bin/lua: module 'luci.fs' not found:
    no field package.preload['luci.fs']
    no file './luci/fs.lua'
    no file '/usr/share/lua/luci/fs.lua'
    no file '/usr/share/lua/luci/fs/init.lua'
    no file '/usr/lib/lua/luci/fs.lua'
    no file '/usr/lib/lua/luci/fs/init.lua'
    no file './luci/fs.so'
    no file '/usr/lib/lua/luci/fs.so'
    no file '/usr/lib/lua/loadall.so'
    no file './luci.so'
    no file '/usr/lib/lua/luci.so'
    no file '/usr/lib/lua/loadall.so'
stack traceback:
    [C]: in function 'require'
    ?: in main chunk
    [C]: in function 'require'
    /usr/sbin/libremap-agent:4: in main chunk
    [C]: ?
```

This commit replaces old luci.fs required file with nixio.fs, which provides the same functions plus many more (check API references [[2]](http://luci.subsignal.org/api/luci/modules/luci.fs.html) and [[3]](http://luci.subsignal.org/api/nixio/modules/nixio.fs.html) respectively)

[1] https://github.com/openwrt/luci/commit/e91b603acc0920f998ae57704a9d97b83ee284e4
[2] http://luci.subsignal.org/api/luci/modules/luci.fs.html
[3] http://luci.subsignal.org/api/nixio/modules/nixio.fs.html
