### PR TITLE
add qmp plugin

### DIFF
--- a/libremap-agent/Makefile
+++ b/libremap-agent/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libremap-agent
-PKG_RELEASE:=0.1.8
+PKG_RELEASE:=0.1.8.1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
 include $(INCLUDE_DIR)/package.mk
@@ -75,6 +75,7 @@ $(eval $(call BuildPlugin,system,system,))
 $(eval $(call BuildPlugin,wireless,wireless,))
 $(eval $(call BuildPlugin,babel,babel,))
 $(eval $(call BuildPlugin,bmx6,bmx6,))
+$(eval $(call BuildPlugin,qmp,qmp,))
 
 define Package/libremap-agent
   SECTION:=utilities

--- a/libremap-agent/files/etc/uci-defaults/80_libremap-agent
+++ b/libremap-agent/files/etc/uci-defaults/80_libremap-agent
@@ -71,6 +71,9 @@ config plugin 'babel'
 
 config plugin 'bmx6'
 	option enabled '0'
+	
+config plugin 'qmp'
+	option enabled '0'
 EOF
 }
 

--- a/libremap-agent/luasrc/libremap/plugins/qmp.lua
+++ b/libremap-agent/luasrc/libremap/plugins/qmp.lua
@@ -1,0 +1,29 @@
+--[[
+
+Copyright 2017 Roger Pueyo Centelles <roger.pueyo@guifi.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+]]--
+
+local uci = (require 'uci').cursor()
+
+function insert(doc, options)
+    -- get values from qMp config
+    local community_name = tostring(uci:get('qmp', 'node', 'community_name'))
+    local mesh_name = tostring(uci:get('qmp', 'node', 'mesh_name'))
+    local device_id = tostring(uci:get('qmp', 'node', 'device_id'))
+
+    -- store in doc
+    doc.community_name = community_name
+    doc.mesh_name = mesh_name
+    doc.device_id = device_id
+end
+
+return {
+    insert = insert
+}

--- a/libremap-agent/luasrc/libremap/plugins/wireless.lua
+++ b/libremap-agent/luasrc/libremap/plugins/wireless.lua
@@ -52,7 +52,7 @@ local function read_wifilinks()
    local macs = {}
    for _, dev in ipairs(wifidevs) do
       for _, net in ipairs(dev:get_wifinets()) do
-         local local_mac = string.upper(ntm:get_interface(net.iwdata.ifname).dev.macaddr)
+         local local_mac = string.upper(ntm:get_interface(net.iwinfo.ifname).dev.macaddr)
          local channel = net:channel()
          local assoclist = net.iwinfo.assoclist or {}
          for station_mac, link_data in pairs(assoclist) do
@@ -62,7 +62,7 @@ local function read_wifilinks()
                alias_remote = station_mac,
                quality = link_quality(link_data.signal),
                attributes = {
-                  interface = net.iwdata.ifname,
+                  interface = net.iwinfo.ifname,
                   local_mac = local_mac,
                   station_mac = station_mac,
                   channel = channel,


### PR DESCRIPTION
This plugin is useful for qMp to report a few device settings used for creating Guifi.net's web page links maps.